### PR TITLE
Only deploy builds.json if it is non-empty

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -2,4 +2,5 @@
 set -euo pipefail
 cd $(dirname "$0")
 ./generate.sh 2>/dev/null | jq . > builds.json.new
+test $(stat -c %s builds.json.new) -gt 0
 mv builds.json.new builds.json


### PR DESCRIPTION
It appears that https://sonic.software sometimes shows no download links. When that is the case, https://sonic.software/builds.json is empty. Presumably this happens when `generate.sh` fails for some reason (which is impossible for me to debug since I cannot see the cron output).

In any case, ensuring the generated `builds.json` file is non-empty before deploying it should prevent the site ending up in a situation with no download links.