### PR TITLE
Increase virtual machine RAM size to 4096MB

### DIFF
--- a/download-gns3a.sh
+++ b/download-gns3a.sh
@@ -49,7 +49,7 @@ echo "
     \"qemu\": {
         \"adapter_type\": \"e1000\",
         \"adapters\": 10,
-        \"ram\": 2048,
+        \"ram\": 4096,
         \"hda_disk_interface\": \"virtio\",
         \"arch\": \"x86_64\",
         \"console_type\": \"telnet\",


### PR DESCRIPTION
This PR increases the VM RAM size from 2048 to 4096MB to avoid issues with OOM.

With the 2048MB of RAM, I could not use the latest master SONiC image SONiC-master-656617 with GNS3. 
I continuously observed: Kernel panic - not syncing: Out of memory.